### PR TITLE
Added functionality for multiple devices and fixed stop record option

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,10 @@ Short options take same arguments as their long counterpart.
   -v, --version              display version and exit
 
 OPTIONS TO USE WITH RECORD
-  -D, --device NAME          pick recording device (either path or descriptive name,
-                                                    see `libinput list-kernel-devices`)
+  -D, --device {NAME}        pick recording devices (either path or descriptive name,
+                                                    see \`libinput list-kernel-devices\`)
+                             this flag can take multiple arguments as
+                             you can specify multiple devices to record at same time
 
 OPTIONS TO USE WITH PLAY
   -d, --delay NUMBER         set replay time in ms (default 12ms)
@@ -114,3 +116,8 @@ See my dotfiles for [usage example](https://github.com/Darukutsu/dotfiles/blob/m
 - [ ] proper mouse support?
 - [ ] proper tty support?
 - [ ] potentional issues with keys which upstate wasn't recorded... e.g. my kill-sequence `keydown super+ctrl+q; keyup super` will result in pressing `CTRL+Q`
+
+##### Warning
+
+Currently you can record any device since we using libinput to record keystrokes, however since we haven't implemented new parsing for any other device than keyboard yet, you are limited to `keystrokes -p -m` option.
+Also you might experience weird issues with mouse sensitivity.

--- a/keystrokes
+++ b/keystrokes
@@ -57,7 +57,7 @@ macro_record() {
   file="$1"
   file=${file:="$(mktemp --suff=.macro)"}
   printf "recording macro, press Ctrl+C to save..."
-  libinput record "$device_names" --show-keycodes "$file"
+  libinput record $device_names --show-keycodes "$file"
 }
 
 macro_play() {

--- a/keystrokes
+++ b/keystrokes
@@ -159,7 +159,7 @@ while [ $# -gt 0 ]; do
     ;;
   -D | --device)
     while [ $# -gt 0 ]; do
-      if [[ -z "$2" || "$2" =~ ^- ]]; then
+      if [ -z "$2" ] || echo "$2" | grep -q '^-'; then
         shift
         break
       fi
@@ -167,7 +167,7 @@ while [ $# -gt 0 ]; do
       if [ -n "$device_name" ]; then
         device_names="$device_names $device_name"
       else
-        printf "Device '$2' not found!\n"
+        printf "Device '%s' not found!\n" "$2"
       fi
       shift
     done
@@ -205,7 +205,7 @@ while [ $# -gt 0 ]; do
     ;;
   -s | --stop-record)
     pid=$(pgrep -a keystrokes | grep '\-r' | cut -d' ' -f1)
-    if [ -n $pid ]; then
+    if [ -n "$pid" ]; then
       # shellcheck disable=2046,2086
       kill -2 $(pstree -p $pid | grep -o '[0-9]*' | tail -n1)
     fi
@@ -214,7 +214,7 @@ while [ $# -gt 0 ]; do
     ;;
   -S | --stop-replay)
     pid=$(pgrep -a keystrokes | grep '\-p' | cut -d' ' -f1)
-    if [ -n $pid ]; then
+    if [ -n "$pid" ]; then
       # shellcheck disable=2046,2086
       kill $(pstree -p $pid | grep -o '[0-9]*' | tail -n1)
     fi

--- a/keystrokes
+++ b/keystrokes
@@ -52,13 +52,14 @@ Run \`macro -R\`, this will autodelete last unnamed recorded file.
 timemills=12
 repeat_count=1
 ismirroring=false
-device_name=
+device_names=()
 
 macro_record() {
   file="$1"
   file=${file:="$(mktemp --suff=.macro)"}
   printf "recording macro, press Ctrl+C to save..."
-  libinput record "$device_name" --show-keycodes "$file"
+  devices_string="${device_names[*]}"
+  libinput record $devices_string --show-keycodes "$file"
 }
 
 macro_play() {
@@ -154,12 +155,19 @@ while [ $# -gt 0 ]; do
     shift 2
     ;;
   -D | --device)
-    [ $# -lt 2 ] && {
-      printf "missing argument!"
-      exit 1
-    }
-    device_name=$(libinput list-kernel-devices | grep -i "$2" | tail -n1 | cut -f1 | tr -d ":")
-    shift 2
+    while [ $# -gt 0 ]; do
+      if [[ -z "$2" || "$2" =~ ^- ]]; then
+        shift
+        break
+      fi
+      device_name=$(libinput list-kernel-devices | grep -i "$2" | tail -n1 | cut -f1 | tr -d ":")
+      if [ -n "$device_name" ]; then
+        device_names+=("$device_name")
+      else
+        printf "Device '$2' not found!\n"
+      fi
+      shift
+    done
     ;;
   -h | --help)
     print_help
@@ -195,7 +203,7 @@ while [ $# -gt 0 ]; do
   -s | --stop-record)
     pid=$(pgrep -a keystrokes | grep '\-r' | cut -d' ' -f1)
     if [ -n $pid ]; then
-      kill $(pstree -p $pid | grep -o '[0-9]*' | tail -n1)
+      kill -2 $(pstree -p $pid | grep -o '[0-9]*' | tail -n1)
     fi
     #pkill -P "$(pgrep keystrokes | head -n1)"
     exit $?
@@ -231,8 +239,8 @@ while [ $# -gt 0 ]; do
 done
 
 if [ "$isrecord" = true ]; then
-  if [ -z "$device_name" ]; then
-    printf "Please specify device -D, --device"
+  if [ ${#device_names[@]} -eq  0 ]; then
+    printf "Please specify at least one device with -D, --device"
     exit 1
   fi
   macro_record "$macroname"

--- a/keystrokes
+++ b/keystrokes
@@ -18,8 +18,10 @@ Short options take same arguments as their long counterpart.
   -v, --version              display version and exit
 
 OPTIONS TO USE WITH RECORD
-  -D, --device NAME          pick recording devices (either path or descriptive name,
+  -D, --device {NAME}        pick recording devices (either path or descriptive name,
                                                     see \`libinput list-kernel-devices\`)
+                             this flag can take multiple arguments as 
+                             you can specify multiple devices to record at same time
 
 OPTIONS TO USE WITH PLAY
   -d, --delay NUMBER         set replay time in ms (default 12ms)
@@ -57,6 +59,8 @@ macro_record() {
   file="$1"
   file=${file:="$(mktemp --suff=.macro)"}
   printf "recording macro, press Ctrl+C to save..."
+  # splitting is here intentional
+  # shellcheck disable=2086
   libinput record $device_names --show-keycodes "$file"
 }
 

--- a/keystrokes
+++ b/keystrokes
@@ -18,9 +18,8 @@ Short options take same arguments as their long counterpart.
   -v, --version              display version and exit
 
 OPTIONS TO USE WITH RECORD
-  -D, --device NAME          pick recording device (either path or descriptive name,
+  -D, --device NAME          pick recording devices (either path or descriptive name,
                                                     see \`libinput list-kernel-devices\`)
-                             this is usefull for remote activating in DESKTOP/WM
 
 OPTIONS TO USE WITH PLAY
   -d, --delay NUMBER         set replay time in ms (default 12ms)
@@ -52,18 +51,18 @@ Run \`macro -R\`, this will autodelete last unnamed recorded file.
 timemills=12
 repeat_count=1
 ismirroring=false
-device_names=()
+device_names=""
 
 macro_record() {
   file="$1"
   file=${file:="$(mktemp --suff=.macro)"}
   printf "recording macro, press Ctrl+C to save..."
-  devices_string="${device_names[*]}"
-  libinput record $devices_string --show-keycodes "$file"
+  libinput record "$device_names" --show-keycodes "$file"
 }
 
 macro_play() {
   file="$1"
+  # shellcheck disable=2012
   if ! file=${file:="$(ls -t /tmp/*.macro | head -n1)"}; then
     printf "no macro found, record macro first"
     exit 2
@@ -98,6 +97,7 @@ macro_play() {
         elif [ "$keystatus" -eq 0 ]; then
           # execute final combo before deleting it
           # splitting is here intentional
+          # shellcheck disable=2086
           $xydotool "$timemills" $keystroke
           keystroke=$(printf "%s" "$keystroke" | sed "s/+\?$((key + 8))//")
           # forward check for multiple zeros following to prevent from unintentional repetitions
@@ -121,6 +121,7 @@ EOF
         elif [ "$keystatus" -eq 0 ]; then
           keystroke="$keystroke $key:0"
           # splitting is here intentional
+          # shellcheck disable=2086
           $xydotool "$timemills" $keystroke
           keystroke=$(printf "%s" "$keystroke" | sed "s/ *$key:1//")
         fi
@@ -130,6 +131,7 @@ EOF
       if [ "$keystatus" -eq 2 ]; then
         export YDOTOOL_SOCKET="$YDOTOOL_SOCKET"
         # splitting is here intentional
+        # shellcheck disable=2086
         $xydotool "$timemills" $keystroke
       fi
     done <"$keys_parsed"
@@ -140,6 +142,7 @@ EOF
 
 macro_remove() {
   file="$1"
+  # shellcheck disable=2012
   file=${file:="$(ls -t /tmp/*.macro | head -n1)"}
   rm "$file"
 }
@@ -162,7 +165,7 @@ while [ $# -gt 0 ]; do
       fi
       device_name=$(libinput list-kernel-devices | grep -i "$2" | tail -n1 | cut -f1 | tr -d ":")
       if [ -n "$device_name" ]; then
-        device_names+=("$device_name")
+        device_names="$device_names $device_name"
       else
         printf "Device '$2' not found!\n"
       fi
@@ -203,6 +206,7 @@ while [ $# -gt 0 ]; do
   -s | --stop-record)
     pid=$(pgrep -a keystrokes | grep '\-r' | cut -d' ' -f1)
     if [ -n $pid ]; then
+      # shellcheck disable=2046,2086
       kill -2 $(pstree -p $pid | grep -o '[0-9]*' | tail -n1)
     fi
     #pkill -P "$(pgrep keystrokes | head -n1)"
@@ -211,6 +215,7 @@ while [ $# -gt 0 ]; do
   -S | --stop-replay)
     pid=$(pgrep -a keystrokes | grep '\-p' | cut -d' ' -f1)
     if [ -n $pid ]; then
+      # shellcheck disable=2046,2086
       kill $(pstree -p $pid | grep -o '[0-9]*' | tail -n1)
     fi
     exit $?
@@ -239,8 +244,8 @@ while [ $# -gt 0 ]; do
 done
 
 if [ "$isrecord" = true ]; then
-  if [ ${#device_names[@]} -eq  0 ]; then
-    printf "Please specify at least one device with -D, --device"
+  if [ -z "$device_names" ]; then
+    printf "Please specify at least one device with -D, --device\n"
     exit 1
   fi
   macro_record "$macroname"


### PR DESCRIPTION
**Added functionality for multiple devices:**

Keystrokes is amazing, but I did want an ability to record multiple devices at once (keyboard and mouse, for example). As libinput record, the one being used by keystrokes has the ability to record multiple devices I decided to implement that functionality.
Instead of a string containing a device name, this would now contain an array of device names for recording. In given parameters, checks are made that there is an element (gt 0) and that it is not empty or starts with a dash (next option). If it's greater but is another option/empty, it shifts and breaks out of the loop. Otherwise, it runs the same logic of finding the device but adds it to an array instead of initializing a string. Error message also changed to ask for "at least one device" in the -D option.

**SIGINT instead of SIGTERM**

To stop recording, it should use SIGINT instead of SIGTERM, as SIGTERM will truncate the file. The issue becomes apparent when recording multiple devices. Signal kills the process of recording and writing to the file instantly, and it ends up truncating and usually only finishes writing for one device. SIGINT lets the process clean up and close the file, successfully writing everything it needs to before shutting down. I left SIGTERM in stop replay as it doesn't need to finish a process and we want it just to stop.

This does not affect previous scripts and works normally with just one device. Everything was tested with ydotool in Wayland and should work the same in X11.

Readme and help could be updated to clarify that the -D option supports multiple devices instead of one recording device but that I will leave up to the owner.
